### PR TITLE
Remove extra "how" from link

### DIFF
--- a/source/indepth/index2.md.erb
+++ b/source/indepth/index2.md.erb
@@ -14,7 +14,7 @@ section: indepth
       <li><a href="../lightweight_ruby_dependency.html">Lightweight Ruby dependency</a></li>
       <li><a href="../integration_modes.html">Integration modes (Nginx, Apache, Standalone)</a></li>
       <li><a href="../app_autodetection/">How Passenger autodetects applications</a></li>
-      <li><a href="../std_channels.html">How Passenger and the application's stdin, stdout and stderr channels</a></li>
+      <li><a href="../std_channels.html">Passenger and the application's stdin, stdout and stderr channels</a></li>
       <li><a href="request_load_balancing.html">Request load balancing</a></li>
       <li><a href="../request_queueing.html">Request queueing</a> <span class="label label-warning">todo</span></li>
       <li><a href="../turbocaching.html">Turbocaching</a> <span class="label label-warning">todo</span></li>


### PR DESCRIPTION
Heya folks! This is a super minor edit. It just updates link's contents to match the title of it's associated page.

Thank you for all you do with passenger and the open-source community. :balloon: :cake: