### PR TITLE
Fix wrong URL to sinatra example end_result branch

### DIFF
--- a/source/walkthroughs/start/ruby.md.erb
+++ b/source/walkthroughs/start/ruby.md.erb
@@ -101,7 +101,7 @@ The second way is by starting a seperate terminal, changing the working director
 Congratulations! You've passed this tutorial and seen Passenger in action. You can find the end result of this tutorial in the example application's git repository's `end_result` branch:
 
  * [Ruby on Rails example: end result](https://github.com/phusion/passenger-ruby-rails-demo/tree/end_result)
- * [Sinatra example: end result](https://github.com/phusion/passenger-ruby-rails-demo/tree/end_result)
+ * [Sinatra example: end result](https://github.com/phusion/passenger-ruby-sinatra-demo/tree/end_result)
 
 ### Next step
 


### PR DESCRIPTION
Sinatra example: end result link refers to Rails example: end result link.
So, I'll fix it.