### PR TITLE
add shebang to rc.local snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can contribute documentation by adding or editing files in the `source` dire
 
 By contributing, you agree to license your contribution under [CC BY SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/).
 
-## Previewing or generating the doucmentation website
+## Previewing or generating the documentation website
 
 You will need Ruby installed in order to preview or generate the documentation website.
 

--- a/source/deploy/automating_app_updates/_ruby_capistrano.md.erb
+++ b/source/deploy/automating_app_updates/_ruby_capistrano.md.erb
@@ -495,7 +495,8 @@ As configured in `config/deploy.rb`, Capistrano will deploy app releases to `/va
   Modify `/etc/rc.local` and change the Passenger invocation to:
 
   <div>
-    <pre class="highlight"><span class="c"># Change working directory to your webapp.</span>
+    <pre class="highlight"><span class="c">#!/bin/sh</span>
+<span class="c"># Change working directory to your webapp.</span>
 <span class="nb">cd</span> /var/www/myapp/current
 &nbsp;
 <span class="c"># Start Passenger Standalone in daemonized mode. Passenger will be started as

--- a/source/deploy/deploy/_standalone.md.erb
+++ b/source/deploy/deploy/_standalone.md.erb
@@ -98,6 +98,7 @@ The easiest way to do that is to add it to the file `/etc/rc.local`. This script
 Here is an example of what you may want to add to `/etc/rc.local`. If there is an `exit` command in rc.local, make sure you add these before the exit command.
 
 <pre class="highlight">
+<span class="c">#!/bin/sh</span>
 <% if locals[:os_config_type] == :tarball %>
 <span class="c"># Since you installed Passenger from tarball, add its `bin` directory to PATH.</span>
 <span class="nb">export</span> <span class="nv">PATH</span>=<span class="o">/path-to-passenger</span>/bin:<span class="nv">$PATH</span>

--- a/source/deploy/standalone/reverse_proxy.md.erb
+++ b/source/deploy/standalone/reverse_proxy.md.erb
@@ -264,6 +264,7 @@ Once you restart the machine, the reverse proxy will no longer be able to serve 
 For example, you can put this in `/etc/rc.local` to make the system start foo and bar at system boot:
 
 ~~~bash
+#!/bin/sh
 # If you installed Passenger from tarball, add its `bin` directory to PATH.
 #export PATH=/path-to-passenger/bin:$PATH
 

--- a/source/walkthroughs/deploy/deploy_app/_standalone_instructions.md.erb
+++ b/source/walkthroughs/deploy/deploy_app/_standalone_instructions.md.erb
@@ -147,6 +147,7 @@ The easiest way to do that is to add it to the file `/etc/rc.local`. This script
 Here is an example of what you may want to add to `/etc/rc.local`. If there is an `exit` command in rc.local, make sure you add these before the exit command.
 
 <pre class="highlight">
+<span class="c">#!/bin/sh</span>
 <% if locals[:os_config_type] == :tarball %>
 <span class="c"># Since you installed Passenger from tarball, add its `bin` directory to PATH.</span>
 <span class="nb">export</span> <span class="nv">PATH</span>=<span class="o">/path-to-passenger</span>/bin:<span class="nv">$PATH</span>


### PR DESCRIPTION
Usually should be obvious, but if you're creating `rc.local` from scratch this is a good reminder that the shebang is required.