### PR TITLE
Use wsgi instead of python for PassengerAppType [ci skip]

### DIFF
--- a/source/deploy/deploy/_apache.md.erb
+++ b/source/deploy/deploy/_apache.md.erb
@@ -59,7 +59,7 @@ Here is an example:
     PassengerAppRoot <span class="o">/path-to-your-app</span>
 
     <span class="c"># Tell Passenger that your app is a <%= language_name %> app</span>
-    PassengerAppType python
+    PassengerAppType wsgi
     PassengerStartupFile <span class="o">passenger_wsgi.py</span>
 
     <span class="c"># Relax Apache security settings</span>


### PR DESCRIPTION
I mean that's obviously a fail in the documentation. My problem was, that it didn't say anything like "Cannot find type python". Which took me a few hours to find out that this is not python, but wsgi..
Passenger just didn't boot at all.. I think an awesome feature would be, to raise an exception and say that the chosen type doesn't exist. I saw that there's a code line [here](https://github.com/phusion/passenger/blob/fca877cc71ad31a10033e4e2a094c48c716beaa5/src/agent/Core/CoreMain.cpp#L1239-L1250) to do this, but this is never printed in my case..

My System:
System: Mac OS X (El capitan)
Apache: 2.4 (installed with homebrew)
Passenger: 5.0.30
