### PR TITLE
Update the link to the Nginx init script.

### DIFF
--- a/source/install/nginx/nginx_init_script.md.erb
+++ b/source/install/nginx/nginx_init_script.md.erb
@@ -21,6 +21,6 @@ A bare Nginx installation works with signals: you start it by invoking it from t
 If you prefer to use an init script then please refer to the following resources:
 
  * [Init script for Ubuntu](https://www.linode.com/docs/websites/nginx/websites-with-nginx-on-ubuntu-12-04-lts-precise-pangolin/)
- * [Init script for Red Hat, Fedora and CentOS](http://www.rackspace.com/knowledge_center/article/centos-adding-an-nginx-init-script)
+ * [Init script for Red Hat, Fedora and CentOS](https://www.nginx.com/resources/wiki/start/topics/examples/redhatnginxinit/)
 
 When using one of those init scripts, please make sure that the paths inside the init script are correct. In particular, the paths to the Nginx binary, to the PID file and to the configuration file must match the actual locations of your Nginx installation.


### PR DESCRIPTION
Update the link to the Nginx init script for Red Hat, Fedora, and CentOS. The old link doesn't work anymore.