### PR TITLE
Specify node 8.9.4

### DIFF
--- a/source/walkthroughs/deploy/install_language_runtime/_nodejs.md.erb
+++ b/source/walkthroughs/deploy/install_language_runtime/_nodejs.md.erb
@@ -30,7 +30,7 @@ Before you can deploy your app on the production server, you need to install Nod
 <% if language_type == :meteor %>
       <pre class="highlight meteor v16"><span class="prompt">$ </span>sudo apt-get update
 <span class="prompt">$ </span>sudo apt-get install -y curl apt-transport-https ca-certificates &amp;&amp;
-  curl --fail -ssL -o setup-nodejs https://deb.nodesource.com/setup_8.x &amp;&amp;
+  curl --fail -ssL -o setup-nodejs https://deb.nodesource.com/setup_8.9.4 &amp;&amp;
   sudo bash setup-nodejs &amp;&amp;
   sudo apt-get install -y nodejs build-essential</pre>
 <% end %>
@@ -55,7 +55,7 @@ Before you can deploy your app on the production server, you need to install Nod
 <% end %>
 <% if language_type == :meteor %>
 <pre class="highlight meteor v16"><span class="prompt">$ </span>sudo yum install -y epel-release curl
-<span class="prompt">$ </span>curl --fail -sSL -o setup-nodejs https://rpm.nodesource.com/setup_8.x
+<span class="prompt">$ </span>curl --fail -sSL -o setup-nodejs https://rpm.nodesource.com/setup_8.9.4
 <span class="prompt">$ </span>sudo bash setup-nodejs
 <span class="prompt">$ </span>sudo yum install -y nodejs gcc-c++ make</pre>
 <% end %>


### PR DESCRIPTION
Installing node 8.11.1 caused bcrypt problems that broke my app. See this issue for more details: https://github.com/meteor/meteor/issues/9804

My understanding is that 8.9.4 is the latest node version that works with meteor.

Hope this fix saves someone from the headaches I've been through over the last couple days.