### PR TITLE
a apt package fix for ubuntu 18.04

### DIFF
--- a/source/install/install/shared/_debian.html.erb
+++ b/source/install/install/shared/_debian.html.erb
@@ -12,10 +12,10 @@ when :apache
 when :nginx
   if dynamic_nginx_module_available?(os_config_type.to_s)
     if edition_type == :oss
-      packages = "libnginx-mod-http-passenger"
+      packages = "libnginx-mod-http-passenger nginx-extras"
       packages_title = "Passenger + Nginx module"
     else
-      packages = "libnginx-mod-http-passenger-enterprise"
+      packages = "libnginx-mod-http-passenger-enterprise nginx-extras"
       packages_title = "Passenger Enterprise + Nginx module"
     end
   else


### PR DESCRIPTION
I couldn't make passenger to work only with `libnginx-mod-http-passenger` package, after added the `nginx-extras` it works fine!