### PR TITLE
Clarify version pinning for APT

### DIFF
--- a/source/install/install/shared/_debian.html.erb
+++ b/source/install/install/shared/_debian.html.erb
@@ -111,7 +111,13 @@ sudo chmod 600 /etc/apt/auth.conf
 sudo apt-get update
 
 <span class="c unselectable"># Install <%= packages_title %></span>
-sudo apt-get install -y <%= packages %></code></pre>
+sudo apt-get install -y <%= packages %>
+
+# If you want to pin to a specific version, you need to specify both <%= packages_title %> and passenger.
+sudo apt-get install -y libnginx-mod-http-passenger=1:5.3.1-1~bionic1 passenger=1:5.3.1-1~bionic1
+
+
+</code></pre>
 
 <% if integration_mode_type == :apache %>
   <% step += 1 %>


### PR DESCRIPTION
Thanks for an awesome project! 🏅 

## Short problem description

When pinning to a version, one must specify `passenger` with the same version.

I realize that the suggested change (this PR) isn't enough, since your install instructions is dynamic.

However, I'd like to help improve the documentation around this, perhaps in an info-box or similar.

But before I suggest more changes I'd like to hear your thoughts on this, just to make sure I've understood the issue correctly!

## Longer problem description

Ran into an issue where our install wouldn't work:

```sh
sudo apt install libnginx-mod-http-passenger=1:5.3.1-1~bionic1
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libnginx-mod-http-passenger : Depends: passenger (= 1:5.3.1-1~bionic1) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.

```

However, when pinning the `passenger` package too it works:

```sh
sudo apt install libnginx-mod-http-passenger=1:5.3.1-1~bionic1 passenger=1:5.3.1-1~bionic1
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  fonts-lato javascript-common libjs-jquery libruby2.5 rake ruby ruby-did-you-mean ruby-minitest ruby-net-telnet ruby-power-assert ruby-rack ruby-test-unit ruby2.5 rubygems-integration zip
Suggested packages:
  ri ruby-dev bundler
Recommended packages:
  passenger-doc passenger-dev
The following NEW packages will be installed:
  fonts-lato javascript-common libjs-jquery libnginx-mod-http-passenger libruby2.5 passenger rake ruby ruby-did-you-mean ruby-minitest ruby-net-telnet ruby-power-assert ruby-rack ruby-test-unit ruby2.5 rubygems-integration zip
0 upgraded, 17 newly installed, 0 to remove and 17 not upgraded.
Need to get 9,007 kB of archives.
After this operation, 41.2 MB of additional disk space will be used.
Do you want to continue? [Y/n] n
```

This is the content of the apt source:
```sh
cat /etc/apt/sources.list.d/passenger-nginx.list 
deb      "https://oss-binaries.phusionpassenger.com/apt/passenger" bionic main
```