### PR TITLE
group boolean tests for package installations

### DIFF
--- a/source/advanced_guides/install_and_upgrade/install_os_content/_redhat.html.erb
+++ b/source/advanced_guides/install_and_upgrade/install_os_content/_redhat.html.erb
@@ -187,7 +187,7 @@ sudo chmod 600 /etc/yum.repos.d/passenger.repo
 <% end -%>
 
 <span class="c unselectable"># Install <%= packages_title %></span>
-sudo yum install -y <%= packages %> || sudo yum-config-manager --enable cr && sudo yum install -y <%= packages %></code></pre>
+sudo yum install -y <%= packages %> || { sudo yum-config-manager --enable cr && sudo yum install -y <%= packages %> ; }</code></pre>
 <% if integration_mode_type == :apache %>
   <% step += 1 %>
   <h2>Step <%= step %>: restart Apache</h2>


### PR DESCRIPTION
Update "yum install ... || yum-config-manager --enable .. && yum install ..."
to only attempt the second installation if the first attempt failed. Without grouping,
the second yum install is attempted if yum install or yum-config-manager terminates
successfully.