### PR TITLE
Unused and confusing message in Edit Nginx Config File

### DIFF
--- a/source/walkthroughs/deploy/deploy_app/_nginx_instructions.html.md.erb
+++ b/source/walkthroughs/deploy/deploy_app/_nginx_instructions.html.md.erb
@@ -56,25 +56,6 @@ myappuser$ ...</span>
 <% substep += 1 %>
 <%= h3(id_prefix, "#{header_step}.#{substep} Edit Nginx configuration file") %>
 
-<div class="supported_redhat_instructions supported_debian_instructions">
-  <p>
-    We need to create an Nginx configuration file and setup a virtual host entry that points to your app. This virtual host entry tells Nginx (and Passenger) where your app is located.
-  </p>
-  <div>
-    <div class="supported_debian_instructions">
-      <pre class="highlight"><span class="prompt">$ </span>sudo nano /etc/nginx/sites-enabled/<span class="o">myapp</span>.conf</pre>
-    </div>
-    <div class="unsupported_debian_instructions">
-      <pre class="highlight"><span class="prompt">$ </span>sudo nano /etc/nginx/conf.d/<span class="o">myapp</span>.conf</pre>
-    </div>
-  </div>
-  <p>
-    Replace <code>myapp</code> with your app's name.
-  </p>
-  <p>
-    Put this inside the file:
-  </p>
-</div>
 <div class="unsupported_redhat_instructions unsupported_debian_instructions">
   <p>
     We need to edit your Nginx configuration file and setup a virtual host entry that points to your app. This virtual host entry tells Nginx (and Passenger) where your app is located.


### PR DESCRIPTION
It seems to me that those messages are forgotten to be deleted.

1. It says: `Put this inside the file:`, but no codes are provided.
2. `We need to create an Nginx configuration file and setup a virtual host entry that points to your app. This virtual host entry tells Nginx (and Passenger) where your app is located.` is duplicated with next paragraph. Which I suspect these message are suppose to be deleted.